### PR TITLE
Changes to bval/bvec arg handling

### DIFF
--- a/workflows/TVB_pipeline.py
+++ b/workflows/TVB_pipeline.py
@@ -81,9 +81,9 @@ for opt, arg in opts:
         diffusion_rawdata = arg
     elif opt in ('-f', '--functional-rawdata'):
         functional_rawdata = arg
-    elif opt is '--bval':
+    elif opt == '--bval':
         bval_file = arg
-    elif opt is '--bev':
+    elif opt == '--bvec':
         bvec_file = arg
 
 # Check if all the obligatory inputs are set


### PR DESCRIPTION
replaced 'is' by '==', perhaps because 'opt' and '--bval' might not point to the same object (see https://stackoverflow.com/questions/132988/is-there-a-difference-between-and-is)

replaced '--bev' by '--bvec', perhaps just a typo